### PR TITLE
Fix idle timeout not firing after credential provider interactions.

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -52,5 +52,9 @@
                 android:name="android.credentials.provider"
                 android:resource="@xml/provider"/>
         </service>
+
+        <receiver
+            android:name=".IdleTimeoutReceiver"
+            android:exported="false" />
     </application>
 </manifest>

--- a/app/src/main/java/se/koditoriet/snout/vault/Vault.kt
+++ b/app/src/main/java/se/koditoriet/snout/vault/Vault.kt
@@ -65,6 +65,7 @@ class Vault(
         check(_state.value != InternalState.Uninitialized)
 
         if (_state.value !is InternalState.Unlocked) {
+            Log.i(TAG, "Unlocking vault")
             val repository = withDbDek(authenticator, dbKey) {
                 repositoryFactory(dbFile.value.name, it)
             }
@@ -74,6 +75,7 @@ class Vault(
 
     fun lock() {
         check(_state.value != InternalState.Uninitialized)
+        Log.i(TAG, "Locking vault")
         unlockState?.repository?.close()
         _state.value = InternalState.Locked
     }


### PR DESCRIPTION
Previously, the idle timeout would fire correctly after backgrounding MainActivity, but not fire until the next time we got foregrounded after finishing a credential provider activity. This might seem harmless - the app would be locked the next time the user interacts with it after all, and all secrets are locked up in SE/TEE anyway - but would leave the metadata encryption keys in memory indefinitely. Not the worst vulnerability out there (a compromised OS or cold boot attacker would gain a larger time window to extract your account list), but ugly nonetheless.

This commit replaces the flaky coroutine-based timeout with a proper AlarmManager-based one.