### PR TITLE
Properly disable screen security when the setting is changed.

### DIFF
--- a/app/src/main/java/se/koditoriet/snout/MainActivity.kt
+++ b/app/src/main/java/se/koditoriet/snout/MainActivity.kt
@@ -98,10 +98,9 @@ fun MainActivity.MainScreen(viewModel: SnoutViewModel) {
 
     LaunchedEffect(config.screenSecurityEnabled) {
         if (config.screenSecurityEnabled) {
-            window.setFlags(
-                WindowManager.LayoutParams.FLAG_SECURE,
-                WindowManager.LayoutParams.FLAG_SECURE,
-            )
+            window.addFlags(WindowManager.LayoutParams.FLAG_SECURE)
+        } else {
+            window.clearFlags(WindowManager.LayoutParams.FLAG_SECURE)
         }
     }
 


### PR DESCRIPTION
Previously, disabling screen security did not take effect until after restart.