### PR TITLE
Move TOTP secret rerender avoidance into ReorderableList.

### DIFF
--- a/app/src/main/java/se/koditoriet/fenris/ui/components/listview/ReorderableList.kt
+++ b/app/src/main/java/se/koditoriet/fenris/ui/components/listview/ReorderableList.kt
@@ -45,10 +45,13 @@ interface ReorderableListItem {
     val sortOrder: Long
     val onClickLabel: String
     val onLongClickLabel: String
+    val visibleDataHash: Int
+
     fun filterPredicate(filter: String): Boolean
     fun onUpdateSortOrder(sortOrder: Long)
     fun onClick()
     fun onLongClick()
+
     @Composable fun RowScope.Render()
 }
 
@@ -65,14 +68,12 @@ fun <T : ReorderableListItem> ReorderableList(
     onReindexItems: () -> Unit,
 ) {
     val isManuallySortable = filter.isNullOrEmpty() && sortMode == SortMode.Manual
-    val reorderableItems = remember {
-        mutableStateListOf<T>().apply { addAll(items) }
-    }
+    val reorderableItems = remember { mutableStateListOf<T>() }
 
     // The parent holds the secret list with SnapshotFlow, and feeds it to this component.
     // We need to update our reorderableSecrets list when the parent updates, otherwise
     // we only get an empty secrets list to render.
-    LaunchedEffect(items) {
+    LaunchedEffect(items.map { it.visibleDataHash }) {
         reorderableItems.clear()
         reorderableItems.addAll(items)
     }

--- a/app/src/main/java/se/koditoriet/fenris/ui/screens/main/passkeys/PasskeyListItem.kt
+++ b/app/src/main/java/se/koditoriet/fenris/ui/screens/main/passkeys/PasskeyListItem.kt
@@ -33,6 +33,13 @@ class PasskeyListItem(
     override val onLongClickLabel: String
         get() = appStrings.generic.selectItem
 
+    override val visibleDataHash: Int by lazy {
+        listOf(
+            passkey.credentialId.hashCode(),
+            passkey.displayName.hashCode(),
+        ).hashCode()
+    }
+
     override fun filterPredicate(filter: String): Boolean = (
             filter in passkey.displayName.lowercase() ||
                     filter in passkey.userName.lowercase() ||

--- a/app/src/main/java/se/koditoriet/fenris/ui/screens/main/secrets/TotpSecretListItem.kt
+++ b/app/src/main/java/se/koditoriet/fenris/ui/screens/main/secrets/TotpSecretListItem.kt
@@ -71,6 +71,14 @@ class TotpSecretListItem(
     override val onLongClickLabel: String
         get() = environment.appStrings.generic.selectItem
 
+    override val visibleDataHash: Int by lazy {
+        listOf(
+            totpSecret.id.hashCode(),
+            totpSecret.issuer.hashCode(),
+            totpSecret.account.hashCode(),
+        ).hashCode()
+    }
+
     override fun filterPredicate(filter: String): Boolean =
         filter in totpSecret.issuer.lowercase() || filter in (totpSecret.account?.lowercase() ?: "")
 

--- a/app/src/main/java/se/koditoriet/fenris/viewmodel/ListSecretsViewModel.kt
+++ b/app/src/main/java/se/koditoriet/fenris/viewmodel/ListSecretsViewModel.kt
@@ -4,7 +4,6 @@ import android.app.Application
 import android.net.Uri
 import android.util.Log
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.first
 import kotlinx.serialization.ExperimentalSerializationApi
 import kotlinx.serialization.Serializable
@@ -22,9 +21,7 @@ private const val TAG = "ListSecretsViewModel"
 
 class ListSecretsViewModel(private val app: Application) : ViewModelBase(app) {
     val secrets: Flow<List<TotpSecret>>
-        get() = vault.totpSecrets.distinctUntilChanged { oldList, newList ->
-            oldList.map { it.copy(timeOfLastUse = null) } == newList.map { it.copy(timeOfLastUse = null) }
-        }
+        get() = vault.totpSecrets
 
     fun onLockVault() = onIOThread { vault.lockVault() }
     fun onAddSecret(newSecret: NewTotpSecret) = withVault { addTotpSecret(newSecret) }


### PR DESCRIPTION
We can preserve the instant update properties of the secrets flow while still avoiding re-rendering the secret list on timeOfLastUse update by keying the list item update LaunchedEffect on some representation of the data that's actually visible in the reordered list.

This makes the modification to the state visibility nicely localized and gives all users of ReorderableList a simple way to specify which properties of the list item should cause a re-render when updated.